### PR TITLE
allow older versions of puppet to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,6 @@ Specify a custom cron_weekday. Default value: '*'
 #### `repo_name`
 Specify a custom name for the yum and apt repo. Default value: 'ksplice'
 
-#### `repo_ensure`
-Specify the ensure value for the yum and apt repo. Default value: 'present'
-
 #### `repo_yum_baseurl_prefix`
 Specify a baseurl_prefix for the yum repo. It isn't documented anywhere but you can mirror the uptrack packages from ksplice.com using rsync. Default value: 'http://www.ksplice.com/yum/uptrack/'
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,6 @@ class ksplice (
   $cron_weekday             = $ksplice::params::cron_weekday,
 
   $repo_name                = $ksplice::params::repo_name,
-  $repo_ensure              = $ksplice::params::repo_ensure,
   $repo_yum_baseurl_prefix  = $ksplice::params::repo_yum_baseurl_prefix,
   $repo_apt_location        = $ksplice::params::repo_apt_location,
   $repo_enabled             = $ksplice::params::repo_enabled,
@@ -32,7 +31,6 @@ class ksplice (
     validate_bool($config_autoinstall)
 
     validate_string($repo_name)
-    validate_re($repo_ensure, '^(present|absent)')
     validate_string($repo_yum_baseurl_prefix)
     validate_string($repo_apt_location)
     validate_bool($repo_enabled)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,6 @@ class ksplice::params {
   $cron_weekday             = '*'
 
   $repo_name                = 'ksplice'
-  $repo_ensure              = 'present'
   $repo_yum_baseurl_prefix  = 'http://www.ksplice.com/yum/uptrack'
   $repo_apt_location        = 'http://www.ksplice.com/apt/'
   $repo_enabled             = true

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -11,8 +11,8 @@ class ksplice::repo {
 
       yumrepo {$ksplice::repo_name:
         baseurl  => "${ksplice::repo_yum_baseurl_prefix}/${os}/\$releasever/\$basearch/",
-        enabled  => $ksplice::repo_enabled,
-        gpgcheck => $ksplice::repo_gpgcheck,
+        enabled  => bool2num($ksplice::repo_enabled),
+        gpgcheck => bool2num($ksplice::repo_gpgcheck),
         gpgkey   => $ksplice::repo_gpgkey,
       }
     }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -10,7 +10,6 @@ class ksplice::repo {
       }
 
       yumrepo {$ksplice::repo_name:
-        ensure   => $ksplice::repo_ensure,
         baseurl  => "${ksplice::repo_yum_baseurl_prefix}/${os}/\$releasever/\$basearch/",
         enabled  => $ksplice::repo_enabled,
         gpgcheck => $ksplice::repo_gpgcheck,
@@ -20,7 +19,6 @@ class ksplice::repo {
     'Debian', 'Ubuntu': {
       include ::apt
       apt::source {$ksplice::repo_name:
-        ensure   => $ksplice::repo_ensure,
         location => $ksplice::repo_apt_location,
         repos    => $ksplice::repo_name,
         key      => {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -17,8 +17,8 @@ describe 'ksplice' do
         describe "ksplice::repo" do
           case facts[:osfamily]
           when 'RedHat'
-            it { should contain_yumrepo('ksplice').with_enabled('true') }
-            it { should contain_yumrepo('ksplice').with_gpgcheck('true') }
+            it { should contain_yumrepo('ksplice').with_enabled(1) }
+            it { should contain_yumrepo('ksplice').with_gpgcheck(1) }
             it { should contain_yumrepo('ksplice').with_gpgkey('https://www.ksplice.com/yum/RPM-GPG-KEY-ksplice') }
 
             case facts[:operatingsystem]
@@ -41,12 +41,12 @@ describe 'ksplice' do
 
           describe 'allow custom enabled' do
             let(:params) { {:repo_enabled => false } }
-            it { should contain_yumrepo('ksplice').with_enabled('false') }
+            it { should contain_yumrepo('ksplice').with_enabled(0) }
           end
 
           describe 'allow custom gpgcheck' do
             let(:params) { {:repo_gpgcheck => false } }
-            it { should contain_yumrepo('ksplice').with_gpgcheck('false') }
+            it { should contain_yumrepo('ksplice').with_gpgcheck(0) }
           end
 
           describe 'allow custom gpgkey' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -34,10 +34,6 @@ describe 'ksplice' do
               let(:params) { {:repo_name => 'lsplice' } }
               it { should contain_yumrepo('lsplice') }
             end
-            describe 'allow custom ensure' do
-              let(:params) { {:repo_ensure => 'absent' } }
-              it { should contain_yumrepo('ksplice').with_ensure('absent') }
-            end
             describe 'allow custom repo_yum_baseurl_prefix' do
               let(:params) { {:repo_yum_baseurl_prefix => 'http://mirror.example.com/ksplice/' } }
               it { should contain_yumrepo('ksplice').with_basurl =~ %r{^http://mirror.example.com/ksplice/} }


### PR DESCRIPTION
have to take out the ensure for the yumrepo since it was only added in 3.5. this will break backwards compatibility with the current 1.0.0 release.